### PR TITLE
Add missing Maven artifact blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <module>alfresco-connector-test</module>
     <module>alfresco-connector-product</module>
     <module>alfrescoecm-demo-app</module>
+    <module>alfrescoecm-demo-app</module>
   </modules>
   <scm>
     <developerConnection>scm:git:https://github.com/axonivy-market/alfresco-connector.git</developerConnection>


### PR DESCRIPTION
This PR adds missing Maven artifact blocks to all `meta.json` files in the repository.